### PR TITLE
Enable API integration with offline fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,13 @@ RecipeShare is a cross-platform social cooking application built with .NET MAUI,
 ## 🚀 **Getting Started**
 
 ### Prerequisites
-- .NET 8.0 SDK or later
+- .NET 8.0 SDK or later with mobile workloads installed (Android, iOS, MacCatalyst)
 - Visual Studio 2022 (17.8+) or VS Code with C# extension
-- Android SDK (for Android development)
+- Android SDK tools (for Android development)
 - Xcode (for iOS development on macOS)
 
 ### Running the Project
+Ensure the required mobile workloads are installed. Building will fail if the Android or iOS targets are missing.
 ```bash
 git clone [repository-url]
 cd RecipeShare

--- a/ReciptShare/MauiProgram.cs
+++ b/ReciptShare/MauiProgram.cs
@@ -30,7 +30,7 @@ public static class MauiProgram
         builder.Services.AddTransient<FavoritesViewModel>();
         builder.Services.AddTransient<ShoppingListViewModel>();
         builder.Services.AddTransient<ProfileViewModel>();
-        builder.Services.AddTransient<ReciptDetailViewModel>();
+        builder.Services.AddTransient<RecipeDetailViewModel>();
         builder.Services.AddTransient<AddReciptViewModel>();
         builder.Services.AddTransient<EditProfileViewModel>();
         

--- a/ReciptShare/ViewModels/BrowseViewModel.cs
+++ b/ReciptShare/ViewModels/BrowseViewModel.cs
@@ -3,6 +3,8 @@ using CommunityToolkit.Mvvm.Input;
 using ReciptShare.Models;
 using ReciptShare.Services;
 using System.Collections.ObjectModel;
+using System.Linq;
+using System.Web;
 
 namespace ReciptShare.ViewModels
 {
@@ -29,87 +31,214 @@ namespace ReciptShare.ViewModels
         [ObservableProperty]
         string sortOption = "Latest";
 
-        public List<string> SortOptions { get; } = new List<string> 
-        { 
-            "Latest", 
-            "Popular", 
-            "Rating", 
-            "Cooking Time", 
-            "Alphabetical" 
+        public List<string> SortOptions { get; } = new List<string>
+        {
+            "Latest",
+            "Popular",
+            "Rating",
+            "Cooking Time",
+            "Alphabetical"
         };
 
-        public BrowseViewModel()
+        [ObservableProperty]
+        string apiStatusMessage = string.Empty;
+
+        private readonly MockDataService _mockDataService;
+        private readonly IHttpClientService? _httpClientService;
+
+        public BrowseViewModel(MockDataService mockDataService, IHttpClientService httpClientService)
         {
             Title = "Browse Recipes";
-            LoadData();
+            _mockDataService = mockDataService;
+            _httpClientService = httpClientService;
+
+            AllRecipes = new ObservableCollection<Recipe>();
+            FilteredRecipes = new ObservableCollection<Recipe>();
+            Categories = new ObservableCollection<string>();
+
+            _ = LoadDataAsync();
         }
 
-        private void LoadData()
+        public BrowseViewModel() : this(new MockDataService(), new HttpClientService())
         {
+        }
+
+        private async Task LoadDataAsync()
+        {
+            if (IsBusy) return;
+
+            IsBusy = true;
+
             try
             {
-                var recipes = MockDataService.GetRecipes();
-                AllRecipes = new ObservableCollection<Recipe>(recipes);
-                
-                // Get unique categories
-                var allCategories = recipes
-                    .SelectMany(r => r.Categories)
-                    .Distinct()
-                    .OrderBy(c => c)
-                    .ToList();
-                
-                allCategories.Insert(0, "All");
-                Categories = new ObservableCollection<string>(allCategories);
+                if (_httpClientService != null)
+                {
+                    await _httpClientService.CheckApiHealthAsync();
+                    SetApiStatus(_httpClientService.IsApiAvailable);
+                }
 
-                // Apply initial filtering
-                ApplyFilters();
+                if (_httpClientService?.IsApiAvailable == true)
+                {
+                    await LoadFromApiAsync();
+                }
+                else
+                {
+                    LoadFromMock();
+                }
             }
             catch (Exception ex)
             {
-                Shell.Current.DisplayAlert("Error", $"Failed to load recipes: {ex.Message}", "OK");
+                System.Diagnostics.Debug.WriteLine($"[BrowseViewModel] Error loading data: {ex.Message}");
+                LoadFromMock();
+                SetApiStatus(false);
             }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async Task LoadFromApiAsync()
+        {
+            try
+            {
+                var response = await _httpClientService!.GetAsync<RecipeListResponse>("/recipes?limit=50");
+
+                AllRecipes.Clear();
+
+                if (response?.Recipes?.Any() == true)
+                {
+                    foreach (var recipe in response.Recipes)
+                    {
+                        recipe.SyncFromApi();
+                        AllRecipes.Add(recipe);
+                    }
+
+                    var allCategories = response.Recipes
+                        .SelectMany(r => r.Categories)
+                        .Distinct()
+                        .OrderBy(c => c)
+                        .ToList();
+
+                    allCategories.Insert(0, "All");
+                    Categories = new ObservableCollection<string>(allCategories);
+                }
+
+                await ApplyFiltersAsync();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[BrowseViewModel] API error: {ex.Message}");
+                LoadFromMock();
+                SetApiStatus(false);
+            }
+        }
+
+        private void LoadFromMock()
+        {
+            var recipes = _mockDataService.GetRecipesInstance();
+            AllRecipes = new ObservableCollection<Recipe>(recipes);
+
+            var allCategories = recipes
+                .SelectMany(r => r.Categories)
+                .Distinct()
+                .OrderBy(c => c)
+                .ToList();
+
+            allCategories.Insert(0, "All");
+            Categories = new ObservableCollection<string>(allCategories);
+
+            ApplyFiltersOffline();
         }
 
         partial void OnSearchTextChanged(string value)
         {
-            ApplyFilters();
+            _ = ApplyFiltersAsync();
         }
 
         partial void OnSelectedCategoryChanged(string value)
         {
-            ApplyFilters();
+            _ = ApplyFiltersAsync();
         }
 
         partial void OnSortOptionChanged(string value)
         {
-            ApplyFilters();
+            _ = ApplyFiltersAsync();
         }
 
         [RelayCommand]
-        private void ApplyFilters()
+        private async Task ApplyFiltersAsync()
+        {
+            try
+            {
+                if (_httpClientService?.IsApiAvailable == true)
+                {
+                    var query = HttpUtility.ParseQueryString(string.Empty);
+                    query["limit"] = "50";
+
+                    if (!string.IsNullOrWhiteSpace(SearchText))
+                        query["search"] = SearchText;
+
+                    if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "All")
+                        query["category"] = SelectedCategory;
+
+                    query["sort"] = SortOption switch
+                    {
+                        "Latest" => "created_at",
+                        "Popular" => "likes",
+                        "Rating" => "rating",
+                        "Cooking Time" => "time",
+                        "Alphabetical" => "title",
+                        _ => "created_at"
+                    };
+
+                    var response = await _httpClientService.GetAsync<RecipeListResponse>($"/recipes?{query}");
+
+                    var filteredList = new List<Recipe>();
+
+                    if (response?.Recipes?.Any() == true)
+                    {
+                        foreach (var recipe in response.Recipes)
+                        {
+                            recipe.SyncFromApi();
+                            filteredList.Add(recipe);
+                        }
+                    }
+
+                    FilteredRecipes = new ObservableCollection<Recipe>(filteredList);
+                }
+                else
+                {
+                    ApplyFiltersOffline();
+                }
+            }
+            catch (Exception ex)
+            {
+                Shell.Current.DisplayAlert("Error", $"Failed to filter recipes: {ex.Message}", "OK");
+            }
+        }
+
+        private void ApplyFiltersOffline()
         {
             try
             {
                 var filtered = AllRecipes.AsEnumerable();
 
-                // Apply category filter
                 if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "All")
                 {
                     filtered = filtered.Where(r => r.Categories.Contains(SelectedCategory));
                 }
 
-                // Apply search filter
                 if (!string.IsNullOrWhiteSpace(SearchText))
                 {
                     var searchLower = SearchText.ToLower();
-                    filtered = filtered.Where(r => 
+                    filtered = filtered.Where(r =>
                         r.Title.ToLower().Contains(searchLower) ||
                         r.Description.ToLower().Contains(searchLower) ||
                         r.AuthorName.ToLower().Contains(searchLower) ||
                         r.Categories.Any(c => c.ToLower().Contains(searchLower)));
                 }
 
-                // Apply sorting
                 filtered = SortOption switch
                 {
                     "Latest" => filtered.OrderByDescending(r => r.CreatedDate),
@@ -160,9 +289,9 @@ namespace ReciptShare.ViewModels
             try
             {
                 // Simulate network delay
-                await Task.Delay(1000);
-                
-                LoadData();
+                await Task.Delay(500);
+
+                await LoadDataAsync();
             }
             finally
             {
@@ -174,20 +303,22 @@ namespace ReciptShare.ViewModels
         private async Task ClearSearch()
         {
             SearchText = string.Empty;
+            await ApplyFiltersAsync();
         }
 
         [RelayCommand]
         private async Task ShowFilterOptions()
         {
             var action = await Shell.Current.DisplayActionSheet(
-                "Sort by", 
-                "Cancel", 
-                null, 
+                "Sort by",
+                "Cancel",
+                null,
                 SortOptions.ToArray());
 
             if (!string.IsNullOrEmpty(action) && action != "Cancel")
             {
                 SortOption = action;
+                await ApplyFiltersAsync();
             }
         }
     }

--- a/ReciptShare/ViewModels/FavoritesViewModel.cs
+++ b/ReciptShare/ViewModels/FavoritesViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using ReciptShare.Models;
 using ReciptShare.Services;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace ReciptShare.ViewModels
 {
@@ -20,49 +21,125 @@ namespace ReciptShare.ViewModels
         [ObservableProperty]
         string sortOption = "Latest";
 
-        public List<string> SortOptions { get; } = new List<string> 
-        { 
-            "Latest", 
-            "Rating", 
-            "Cooking Time", 
-            "Alphabetical" 
+        public List<string> SortOptions { get; } = new List<string>
+        {
+            "Latest",
+            "Rating",
+            "Cooking Time",
+            "Alphabetical"
         };
 
-        public FavoritesViewModel()
+        [ObservableProperty]
+        string apiStatusMessage = string.Empty;
+
+        private readonly MockDataService _mockDataService;
+        private readonly IHttpClientService? _httpClientService;
+
+        public FavoritesViewModel(MockDataService mockDataService, IHttpClientService httpClientService)
         {
             Title = "Favorites";
-            CurrentUser = MockDataService.GetCurrentUser();
-            LoadFavorites();
+            _mockDataService = mockDataService;
+            _httpClientService = httpClientService;
+
+            CurrentUser = _mockDataService.GetCurrentUserInstance();
+            FavoriteRecipes = new ObservableCollection<Recipe>();
+
+            _ = LoadFavoritesAsync();
         }
 
-        public void LoadFavorites()
+        public FavoritesViewModel() : this(new MockDataService(), new HttpClientService())
         {
+        }
+
+        public async Task LoadFavoritesAsync()
+        {
+            if (IsBusy) return;
+
+            IsBusy = true;
+
             try
             {
-                var allRecipes = MockDataService.GetRecipes();
-                var favorites = allRecipes.Where(r => r.IsFavorited).ToList();
-                
-                // Apply sorting
-                var sorted = SortOption switch
+                if (_httpClientService != null)
                 {
-                    "Latest" => favorites.OrderByDescending(r => r.CreatedDate),
-                    "Rating" => favorites.OrderByDescending(r => r.Rating),
-                    "Cooking Time" => favorites.OrderBy(r => r.TotalTimeMinutes),
-                    "Alphabetical" => favorites.OrderBy(r => r.Title),
-                    _ => favorites.OrderByDescending(r => r.CreatedDate)
-                };
+                    await _httpClientService.CheckApiHealthAsync();
+                    SetApiStatus(_httpClientService.IsApiAvailable);
+                }
 
-                FavoriteRecipes = new ObservableCollection<Recipe>(sorted);
+                if (_httpClientService?.IsApiAvailable == true)
+                {
+                    await LoadFavoritesFromApiAsync();
+                }
+                else
+                {
+                    LoadFavoritesFromMock();
+                }
             }
             catch (Exception ex)
             {
-                Shell.Current.DisplayAlert("Error", $"Failed to load favorites: {ex.Message}", "OK");
+                System.Diagnostics.Debug.WriteLine($"[FavoritesViewModel] Error loading favorites: {ex.Message}");
+                LoadFavoritesFromMock();
+                SetApiStatus(false);
             }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async Task LoadFavoritesFromApiAsync()
+        {
+            try
+            {
+                var response = await _httpClientService!.GetAsync<RecipeListResponse>("/collections/favorites");
+
+                var list = new List<Recipe>();
+
+                if (response?.Recipes?.Any() == true)
+                {
+                    foreach (var recipe in response.Recipes)
+                    {
+                        recipe.SyncFromApi();
+                        list.Add(recipe);
+                    }
+                }
+
+                list = SortFavorites(list);
+
+                FavoriteRecipes = new ObservableCollection<Recipe>(list);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[FavoritesViewModel] API error: {ex.Message}");
+                LoadFavoritesFromMock();
+                SetApiStatus(false);
+            }
+        }
+
+        private void LoadFavoritesFromMock()
+        {
+            var allRecipes = _mockDataService.GetRecipesInstance();
+            var favorites = allRecipes.Where(r => r.IsFavorited).ToList();
+
+            favorites = SortFavorites(favorites);
+
+            FavoriteRecipes = new ObservableCollection<Recipe>(favorites);
+        }
+
+        private List<Recipe> SortFavorites(List<Recipe> favorites)
+        {
+            return SortOption switch
+            {
+                "Latest" => favorites.OrderByDescending(r => r.CreatedDate).ToList(),
+                "Rating" => favorites.OrderByDescending(r => r.Rating).ToList(),
+                "Cooking Time" => favorites.OrderBy(r => r.TotalTimeMinutes).ToList(),
+                "Alphabetical" => favorites.OrderBy(r => r.Title).ToList(),
+                _ => favorites.OrderByDescending(r => r.CreatedDate).ToList()
+            };
         }
 
         partial void OnSortOptionChanged(string value)
         {
-            LoadFavorites();
+            _ = LoadFavoritesAsync();
         }
 
         [RelayCommand]
@@ -98,13 +175,11 @@ namespace ReciptShare.ViewModels
         private async Task RefreshFavorites()
         {
             IsRefreshing = true;
-            
+
             try
             {
-                // Simulate network delay
-                await Task.Delay(1000);
-                
-                LoadFavorites();
+                await Task.Delay(500);
+                await LoadFavoritesAsync();
             }
             finally
             {
@@ -124,6 +199,7 @@ namespace ReciptShare.ViewModels
             if (!string.IsNullOrEmpty(action) && action != "Cancel")
             {
                 SortOption = action;
+                await LoadFavoritesAsync();
             }
         }
 

--- a/ReciptShare/ViewModels/RecipeDetailViewModel.cs
+++ b/ReciptShare/ViewModels/RecipeDetailViewModel.cs
@@ -1,13 +1,16 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ReciptShare.Models;
+using ReciptShare.Models.Api;
 using ReciptShare.Services;
 using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace ReciptShare.ViewModels
 {
     [QueryProperty(nameof(RecipeId), "id")]
-    public partial class ReciptDetailViewModel : BaseViewModel
+    public partial class RecipeDetailViewModel : BaseViewModel
     {
         [ObservableProperty]
         Recipe currentRecipe;
@@ -39,56 +42,132 @@ namespace ReciptShare.ViewModels
         [ObservableProperty]
         int recipeId;
 
-        public ReciptDetailViewModel()
+        private readonly MockDataService _mockDataService;
+        private readonly IHttpClientService? _httpClientService;
+
+        public RecipeDetailViewModel(MockDataService mockDataService, IHttpClientService httpClientService)
         {
             Title = "Recipe Details";
-            CurrentUser = MockDataService.GetCurrentUser();
+            _mockDataService = mockDataService;
+            _httpClientService = httpClientService;
+
+            CurrentUser = _mockDataService.GetCurrentUserInstance();
             Comments = new ObservableCollection<Comment>();
             Ratings = new ObservableCollection<Rating>();
             InstructionsWithNumbers = new ObservableCollection<NumberedInstruction>();
         }
 
-        partial void OnRecipeIdChanged(int value)
+        public RecipeDetailViewModel() : this(new MockDataService(), new HttpClientService())
         {
-            LoadRecipeData(value);
         }
 
-        private void LoadRecipeData(int id)
+        partial void OnRecipeIdChanged(int value)
+        {
+            _ = LoadRecipeDataAsync(value);
+        }
+
+        private async Task LoadRecipeDataAsync(int id)
         {
             try
             {
-                CurrentRecipe = MockDataService.GetRecipeById(id);
+                if (_httpClientService != null)
+                {
+                    await _httpClientService.CheckApiHealthAsync();
+                }
+
+                if (_httpClientService?.IsApiAvailable == true)
+                {
+                    var response = await _httpClientService.GetAsync<ApiResponse<Recipe>>($"/recipes/{id}");
+                    CurrentRecipe = response?.Data;
+                    CurrentRecipe?.SyncFromApi();
+                }
+                else
+                {
+                    CurrentRecipe = _mockDataService.GetRecipeByIdInstance(id);
+                }
+
                 if (CurrentRecipe != null)
                 {
                     Title = CurrentRecipe.Title;
-                    LoadComments();
-                    LoadRatings();
+                    await LoadComments();
+                    await LoadRatings();
                     LoadNumberedInstructions();
                 }
             }
             catch (Exception ex)
             {
-                // Log error or handle gracefully
-                Shell.Current.DisplayAlert("Error", $"Failed to load recipe: {ex.Message}", "OK");
+                await Shell.Current.DisplayAlert("Error", $"Failed to load recipe: {ex.Message}", "OK");
             }
         }
 
-        private void LoadComments()
+        private async Task LoadComments()
         {
-            var allComments = MockDataService.GetComments();
-            var recipeComments = allComments.Where(c => c.RecipeId == CurrentRecipe.Id).ToList();
             Comments.Clear();
+            if (_httpClientService?.IsApiAvailable == true && !string.IsNullOrEmpty(CurrentRecipe?.ApiId))
+            {
+                try
+                {
+                    var response = await _httpClientService.GetAsync<ApiResponse<List<Comment>>>($"/recipes/{CurrentRecipe!.ApiId}/comments");
+                    if (response?.Data != null)
+                    {
+                        foreach (var c in response.Data)
+                        {
+                            Comments.Add(c);
+                        }
+                    }
+                }
+                catch
+                {
+                    LoadCommentsFromMock();
+                }
+            }
+            else
+            {
+                LoadCommentsFromMock();
+            }
+        }
+
+        private void LoadCommentsFromMock()
+        {
+            var allComments = _mockDataService.GetCommentsInstance();
+            var recipeComments = allComments.Where(c => c.RecipeId == CurrentRecipe!.Id).ToList();
             foreach (var comment in recipeComments)
             {
                 Comments.Add(comment);
             }
         }
 
-        private void LoadRatings()
+        private async Task LoadRatings()
         {
-            var allRatings = MockDataService.GetRatings();
-            var recipeRatings = allRatings.Where(r => r.RecipeId == CurrentRecipe.Id).ToList();
             Ratings.Clear();
+            if (_httpClientService?.IsApiAvailable == true && !string.IsNullOrEmpty(CurrentRecipe?.ApiId))
+            {
+                try
+                {
+                    var response = await _httpClientService.GetAsync<ApiResponse<List<Rating>>>($"/recipes/{CurrentRecipe!.ApiId}/ratings");
+                    if (response?.Data != null)
+                    {
+                        foreach (var r in response.Data)
+                        {
+                            Ratings.Add(r);
+                        }
+                    }
+                }
+                catch
+                {
+                    LoadRatingsFromMock();
+                }
+            }
+            else
+            {
+                LoadRatingsFromMock();
+            }
+        }
+
+        private void LoadRatingsFromMock()
+        {
+            var allRatings = _mockDataService.GetRatingsInstance();
+            var recipeRatings = allRatings.Where(r => r.RecipeId == CurrentRecipe!.Id).ToList();
             foreach (var rating in recipeRatings)
             {
                 Ratings.Add(rating);

--- a/ReciptShare/Views/AddRecipePage.xaml.cs
+++ b/ReciptShare/Views/AddRecipePage.xaml.cs
@@ -6,10 +6,10 @@ public partial class AddRecipePage : ContentPage
 {
     private AddReciptViewModel _viewModel;
 
-    public AddRecipePage()
+    public AddRecipePage(AddReciptViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new AddReciptViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 

--- a/ReciptShare/Views/BrowsePage.xaml.cs
+++ b/ReciptShare/Views/BrowsePage.xaml.cs
@@ -6,10 +6,10 @@ public partial class BrowsePage : ContentPage
 {
     private BrowseViewModel _viewModel;
 
-    public BrowsePage()
+    public BrowsePage(BrowseViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new BrowseViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 

--- a/ReciptShare/Views/EditProfilePage.xaml.cs
+++ b/ReciptShare/Views/EditProfilePage.xaml.cs
@@ -6,10 +6,10 @@ public partial class EditProfilePage : ContentPage
 {
     private EditProfileViewModel _viewModel;
 
-    public EditProfilePage()
+    public EditProfilePage(EditProfileViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new EditProfileViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 

--- a/ReciptShare/Views/FavoritesPage.xaml.cs
+++ b/ReciptShare/Views/FavoritesPage.xaml.cs
@@ -6,10 +6,10 @@ public partial class FavoritesPage : ContentPage
 {
     private FavoritesViewModel _viewModel;
 
-    public FavoritesPage()
+    public FavoritesPage(FavoritesViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new FavoritesViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 
@@ -17,6 +17,6 @@ public partial class FavoritesPage : ContentPage
     {
         base.OnAppearing();
         // Refresh favorites when page appears (in case favorites were changed on other pages)
-        _viewModel.LoadFavorites();
+        _ = _viewModel.LoadFavoritesAsync();
     }
 }

--- a/ReciptShare/Views/ProfilePage.xaml.cs
+++ b/ReciptShare/Views/ProfilePage.xaml.cs
@@ -6,10 +6,10 @@ public partial class ProfilePage : ContentPage
 {
     private ProfileViewModel _viewModel;
 
-    public ProfilePage()
+    public ProfilePage(ProfileViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new ProfileViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 

--- a/ReciptShare/Views/RecipeDetailPage.xaml
+++ b/ReciptShare/Views/RecipeDetailPage.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewmodels="clr-namespace:ReciptShare.ViewModels"
              xmlns:models="clr-namespace:ReciptShare.Models"
-             x:DataType="viewmodels:ReciptDetailViewModel"
+             x:DataType="viewmodels:RecipeDetailViewModel"
              Title="{Binding Title}">
 
     <ScrollView>

--- a/ReciptShare/Views/RecipeDetailPage.xaml.cs
+++ b/ReciptShare/Views/RecipeDetailPage.xaml.cs
@@ -4,14 +4,14 @@ namespace ReciptShare.Views;
 
 public partial class RecipeDetailPage : ContentPage
 {
-    private ReciptDetailViewModel _viewModel;
+    private RecipeDetailViewModel _viewModel;
 
-    public RecipeDetailPage()
+    public RecipeDetailPage(RecipeDetailViewModel viewModel)
     {
         try
         {
             InitializeComponent();
-            _viewModel = new ReciptDetailViewModel();
+            _viewModel = viewModel;
             BindingContext = _viewModel;
         }
         catch (Exception ex)

--- a/ReciptShare/Views/ShoppingListPage.xaml.cs
+++ b/ReciptShare/Views/ShoppingListPage.xaml.cs
@@ -6,10 +6,10 @@ public partial class ShoppingListPage : ContentPage
 {
     private ShoppingListViewModel _viewModel;
 
-    public ShoppingListPage()
+    public ShoppingListPage(ShoppingListViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new ShoppingListViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 


### PR DESCRIPTION
## Summary
- wire up HttpClientService to BrowseViewModel with fallback to mock data
- fetch favorite recipes from the API when available
- update RecipeDetailViewModel to load recipe, comments and ratings from the API
- switch XAML page constructors to receive view models via DI
- install .NET 8.0 SDK and attempt to build the solution

## Testing
- `dotnet build ReciptShare.sln` *(fails: missing wasi-experimental workload)*

------
https://chatgpt.com/codex/tasks/task_e_6841c2fd21bc8323af8153f5163bfa70