### PR TITLE
Enable API integration with offline fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,13 @@ RecipeShare is a cross-platform social cooking application built with .NET MAUI,
 ## 🚀 **Getting Started**
 
 ### Prerequisites
-- .NET 8.0 SDK or later
+- .NET 8.0 SDK or later with mobile workloads installed (Android, iOS, MacCatalyst)
 - Visual Studio 2022 (17.8+) or VS Code with C# extension
-- Android SDK (for Android development)
+- Android SDK tools (for Android development)
 - Xcode (for iOS development on macOS)
 
 ### Running the Project
+Ensure the required mobile workloads are installed. Building will fail if the Android or iOS targets are missing.
 ```bash
 git clone [repository-url]
 cd RecipeShare

--- a/ReciptShare/App.xaml.cs
+++ b/ReciptShare/App.xaml.cs
@@ -1,11 +1,26 @@
-﻿namespace ReciptShare;
+using ReciptShare.Services;
+
+namespace ReciptShare;
 
 public partial class App : Application
 {
-    public App()
+    private readonly IAuthenticationService _authService;
+    private readonly AppShell _shell;
+
+    public App(AppShell shell, IAuthenticationService authService)
     {
         InitializeComponent();
+        _shell = shell;
+        _authService = authService;
 
-        MainPage = new AppShell();
+        MainPage = _shell;
+
+        _shell.Dispatcher.Dispatch(async () =>
+        {
+            if (!_authService.IsAuthenticated)
+            {
+                await _shell.GoToAsync("//welcome");
+            }
+        });
     }
 }

--- a/ReciptShare/AppShell.xaml
+++ b/ReciptShare/AppShell.xaml
@@ -38,4 +38,15 @@
             Icon="profile_icon.png" />
     </TabBar>
 
+    <!-- Authentication Pages -->
+    <ShellContent
+        ContentTemplate="{DataTemplate local:LoginPage}"
+        Route="login" />
+    <ShellContent
+        ContentTemplate="{DataTemplate local:RegisterPage}"
+        Route="register" />
+    <ShellContent
+        ContentTemplate="{DataTemplate local:WelcomePage}"
+        Route="welcome" />
+
 </Shell>

--- a/ReciptShare/MauiProgram.cs
+++ b/ReciptShare/MauiProgram.cs
@@ -23,6 +23,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<IAuthenticationService, AuthenticationService>();
         builder.Services.AddSingleton<IApiStatusService, ApiStatusService>();
         builder.Services.AddSingleton<MockDataService>();
+        builder.Services.AddSingleton<AppShell>();
         
         // Register ViewModels
         builder.Services.AddTransient<HomeViewModel>();
@@ -30,9 +31,12 @@ public static class MauiProgram
         builder.Services.AddTransient<FavoritesViewModel>();
         builder.Services.AddTransient<ShoppingListViewModel>();
         builder.Services.AddTransient<ProfileViewModel>();
-        builder.Services.AddTransient<ReciptDetailViewModel>();
+        builder.Services.AddTransient<RecipeDetailViewModel>();
         builder.Services.AddTransient<AddReciptViewModel>();
         builder.Services.AddTransient<EditProfileViewModel>();
+        builder.Services.AddTransient<LoginViewModel>();
+        builder.Services.AddTransient<RegisterViewModel>();
+        builder.Services.AddTransient<WelcomeViewModel>();
         
         // Register Views
         builder.Services.AddTransient<HomePage>();
@@ -43,6 +47,9 @@ public static class MauiProgram
         builder.Services.AddTransient<RecipeDetailPage>();
         builder.Services.AddTransient<AddRecipePage>();
         builder.Services.AddTransient<EditProfilePage>();
+        builder.Services.AddTransient<LoginPage>();
+        builder.Services.AddTransient<RegisterPage>();
+        builder.Services.AddTransient<WelcomePage>();
 
         builder.Logging.AddDebug();
 

--- a/ReciptShare/Models/ApiModels.cs
+++ b/ReciptShare/Models/ApiModels.cs
@@ -60,8 +60,6 @@ namespace ReciptShare.Models.Api
         [JsonPropertyName("bio")]
         public string? Bio { get; set; }
 
-        [JsonPropertyName("profileImageUrl")]
-        public string? ProfileImageUrl { get; set; }
     }
 
     public class AuthResponse

--- a/ReciptShare/Services/HttpClientService.cs
+++ b/ReciptShare/Services/HttpClientService.cs
@@ -33,7 +33,8 @@ namespace ReciptShare.Services
             _jsonOptions = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                WriteIndented = true
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
 
             InitializeHttpClient();

--- a/ReciptShare/ViewModels/BrowseViewModel.cs
+++ b/ReciptShare/ViewModels/BrowseViewModel.cs
@@ -3,6 +3,8 @@ using CommunityToolkit.Mvvm.Input;
 using ReciptShare.Models;
 using ReciptShare.Services;
 using System.Collections.ObjectModel;
+using System.Linq;
+using System.Web;
 
 namespace ReciptShare.ViewModels
 {
@@ -29,87 +31,214 @@ namespace ReciptShare.ViewModels
         [ObservableProperty]
         string sortOption = "Latest";
 
-        public List<string> SortOptions { get; } = new List<string> 
-        { 
-            "Latest", 
-            "Popular", 
-            "Rating", 
-            "Cooking Time", 
-            "Alphabetical" 
+        public List<string> SortOptions { get; } = new List<string>
+        {
+            "Latest",
+            "Popular",
+            "Rating",
+            "Cooking Time",
+            "Alphabetical"
         };
 
-        public BrowseViewModel()
+        [ObservableProperty]
+        string apiStatusMessage = string.Empty;
+
+        private readonly MockDataService _mockDataService;
+        private readonly IHttpClientService? _httpClientService;
+
+        public BrowseViewModel(MockDataService mockDataService, IHttpClientService httpClientService)
         {
             Title = "Browse Recipes";
-            LoadData();
+            _mockDataService = mockDataService;
+            _httpClientService = httpClientService;
+
+            AllRecipes = new ObservableCollection<Recipe>();
+            FilteredRecipes = new ObservableCollection<Recipe>();
+            Categories = new ObservableCollection<string>();
+
+            _ = LoadDataAsync();
         }
 
-        private void LoadData()
+        public BrowseViewModel() : this(new MockDataService(), new HttpClientService())
         {
+        }
+
+        private async Task LoadDataAsync()
+        {
+            if (IsBusy) return;
+
+            IsBusy = true;
+
             try
             {
-                var recipes = MockDataService.GetRecipes();
-                AllRecipes = new ObservableCollection<Recipe>(recipes);
-                
-                // Get unique categories
-                var allCategories = recipes
-                    .SelectMany(r => r.Categories)
-                    .Distinct()
-                    .OrderBy(c => c)
-                    .ToList();
-                
-                allCategories.Insert(0, "All");
-                Categories = new ObservableCollection<string>(allCategories);
+                if (_httpClientService != null)
+                {
+                    await _httpClientService.CheckApiHealthAsync();
+                    SetApiStatus(_httpClientService.IsApiAvailable);
+                }
 
-                // Apply initial filtering
-                ApplyFilters();
+                if (_httpClientService?.IsApiAvailable == true)
+                {
+                    await LoadFromApiAsync();
+                }
+                else
+                {
+                    LoadFromMock();
+                }
             }
             catch (Exception ex)
             {
-                Shell.Current.DisplayAlert("Error", $"Failed to load recipes: {ex.Message}", "OK");
+                System.Diagnostics.Debug.WriteLine($"[BrowseViewModel] Error loading data: {ex.Message}");
+                LoadFromMock();
+                SetApiStatus(false);
             }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async Task LoadFromApiAsync()
+        {
+            try
+            {
+                var response = await _httpClientService!.GetAsync<RecipeListResponse>("/recipes?limit=50");
+
+                AllRecipes.Clear();
+
+                if (response?.Recipes?.Any() == true)
+                {
+                    foreach (var recipe in response.Recipes)
+                    {
+                        recipe.SyncFromApi();
+                        AllRecipes.Add(recipe);
+                    }
+
+                    var allCategories = response.Recipes
+                        .SelectMany(r => r.Categories)
+                        .Distinct()
+                        .OrderBy(c => c)
+                        .ToList();
+
+                    allCategories.Insert(0, "All");
+                    Categories = new ObservableCollection<string>(allCategories);
+                }
+
+                await ApplyFiltersAsync();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[BrowseViewModel] API error: {ex.Message}");
+                LoadFromMock();
+                SetApiStatus(false);
+            }
+        }
+
+        private void LoadFromMock()
+        {
+            var recipes = _mockDataService.GetRecipesInstance();
+            AllRecipes = new ObservableCollection<Recipe>(recipes);
+
+            var allCategories = recipes
+                .SelectMany(r => r.Categories)
+                .Distinct()
+                .OrderBy(c => c)
+                .ToList();
+
+            allCategories.Insert(0, "All");
+            Categories = new ObservableCollection<string>(allCategories);
+
+            ApplyFiltersOffline();
         }
 
         partial void OnSearchTextChanged(string value)
         {
-            ApplyFilters();
+            _ = ApplyFiltersAsync();
         }
 
         partial void OnSelectedCategoryChanged(string value)
         {
-            ApplyFilters();
+            _ = ApplyFiltersAsync();
         }
 
         partial void OnSortOptionChanged(string value)
         {
-            ApplyFilters();
+            _ = ApplyFiltersAsync();
         }
 
         [RelayCommand]
-        private void ApplyFilters()
+        private async Task ApplyFiltersAsync()
+        {
+            try
+            {
+                if (_httpClientService?.IsApiAvailable == true)
+                {
+                    var query = HttpUtility.ParseQueryString(string.Empty);
+                    query["limit"] = "50";
+
+                    if (!string.IsNullOrWhiteSpace(SearchText))
+                        query["search"] = SearchText;
+
+                    if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "All")
+                        query["category"] = SelectedCategory;
+
+                    query["sort"] = SortOption switch
+                    {
+                        "Latest" => "created_at",
+                        "Popular" => "likes",
+                        "Rating" => "rating",
+                        "Cooking Time" => "time",
+                        "Alphabetical" => "title",
+                        _ => "created_at"
+                    };
+
+                    var response = await _httpClientService.GetAsync<RecipeListResponse>($"/recipes?{query}");
+
+                    var filteredList = new List<Recipe>();
+
+                    if (response?.Recipes?.Any() == true)
+                    {
+                        foreach (var recipe in response.Recipes)
+                        {
+                            recipe.SyncFromApi();
+                            filteredList.Add(recipe);
+                        }
+                    }
+
+                    FilteredRecipes = new ObservableCollection<Recipe>(filteredList);
+                }
+                else
+                {
+                    ApplyFiltersOffline();
+                }
+            }
+            catch (Exception ex)
+            {
+                Shell.Current.DisplayAlert("Error", $"Failed to filter recipes: {ex.Message}", "OK");
+            }
+        }
+
+        private void ApplyFiltersOffline()
         {
             try
             {
                 var filtered = AllRecipes.AsEnumerable();
 
-                // Apply category filter
                 if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "All")
                 {
                     filtered = filtered.Where(r => r.Categories.Contains(SelectedCategory));
                 }
 
-                // Apply search filter
                 if (!string.IsNullOrWhiteSpace(SearchText))
                 {
                     var searchLower = SearchText.ToLower();
-                    filtered = filtered.Where(r => 
+                    filtered = filtered.Where(r =>
                         r.Title.ToLower().Contains(searchLower) ||
                         r.Description.ToLower().Contains(searchLower) ||
                         r.AuthorName.ToLower().Contains(searchLower) ||
                         r.Categories.Any(c => c.ToLower().Contains(searchLower)));
                 }
 
-                // Apply sorting
                 filtered = SortOption switch
                 {
                     "Latest" => filtered.OrderByDescending(r => r.CreatedDate),
@@ -160,9 +289,9 @@ namespace ReciptShare.ViewModels
             try
             {
                 // Simulate network delay
-                await Task.Delay(1000);
-                
-                LoadData();
+                await Task.Delay(500);
+
+                await LoadDataAsync();
             }
             finally
             {
@@ -174,20 +303,22 @@ namespace ReciptShare.ViewModels
         private async Task ClearSearch()
         {
             SearchText = string.Empty;
+            await ApplyFiltersAsync();
         }
 
         [RelayCommand]
         private async Task ShowFilterOptions()
         {
             var action = await Shell.Current.DisplayActionSheet(
-                "Sort by", 
-                "Cancel", 
-                null, 
+                "Sort by",
+                "Cancel",
+                null,
                 SortOptions.ToArray());
 
             if (!string.IsNullOrEmpty(action) && action != "Cancel")
             {
                 SortOption = action;
+                await ApplyFiltersAsync();
             }
         }
     }

--- a/ReciptShare/ViewModels/FavoritesViewModel.cs
+++ b/ReciptShare/ViewModels/FavoritesViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using ReciptShare.Models;
 using ReciptShare.Services;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace ReciptShare.ViewModels
 {
@@ -20,49 +21,125 @@ namespace ReciptShare.ViewModels
         [ObservableProperty]
         string sortOption = "Latest";
 
-        public List<string> SortOptions { get; } = new List<string> 
-        { 
-            "Latest", 
-            "Rating", 
-            "Cooking Time", 
-            "Alphabetical" 
+        public List<string> SortOptions { get; } = new List<string>
+        {
+            "Latest",
+            "Rating",
+            "Cooking Time",
+            "Alphabetical"
         };
 
-        public FavoritesViewModel()
+        [ObservableProperty]
+        string apiStatusMessage = string.Empty;
+
+        private readonly MockDataService _mockDataService;
+        private readonly IHttpClientService? _httpClientService;
+
+        public FavoritesViewModel(MockDataService mockDataService, IHttpClientService httpClientService)
         {
             Title = "Favorites";
-            CurrentUser = MockDataService.GetCurrentUser();
-            LoadFavorites();
+            _mockDataService = mockDataService;
+            _httpClientService = httpClientService;
+
+            CurrentUser = _mockDataService.GetCurrentUserInstance();
+            FavoriteRecipes = new ObservableCollection<Recipe>();
+
+            _ = LoadFavoritesAsync();
         }
 
-        public void LoadFavorites()
+        public FavoritesViewModel() : this(new MockDataService(), new HttpClientService())
         {
+        }
+
+        public async Task LoadFavoritesAsync()
+        {
+            if (IsBusy) return;
+
+            IsBusy = true;
+
             try
             {
-                var allRecipes = MockDataService.GetRecipes();
-                var favorites = allRecipes.Where(r => r.IsFavorited).ToList();
-                
-                // Apply sorting
-                var sorted = SortOption switch
+                if (_httpClientService != null)
                 {
-                    "Latest" => favorites.OrderByDescending(r => r.CreatedDate),
-                    "Rating" => favorites.OrderByDescending(r => r.Rating),
-                    "Cooking Time" => favorites.OrderBy(r => r.TotalTimeMinutes),
-                    "Alphabetical" => favorites.OrderBy(r => r.Title),
-                    _ => favorites.OrderByDescending(r => r.CreatedDate)
-                };
+                    await _httpClientService.CheckApiHealthAsync();
+                    SetApiStatus(_httpClientService.IsApiAvailable);
+                }
 
-                FavoriteRecipes = new ObservableCollection<Recipe>(sorted);
+                if (_httpClientService?.IsApiAvailable == true)
+                {
+                    await LoadFavoritesFromApiAsync();
+                }
+                else
+                {
+                    LoadFavoritesFromMock();
+                }
             }
             catch (Exception ex)
             {
-                Shell.Current.DisplayAlert("Error", $"Failed to load favorites: {ex.Message}", "OK");
+                System.Diagnostics.Debug.WriteLine($"[FavoritesViewModel] Error loading favorites: {ex.Message}");
+                LoadFavoritesFromMock();
+                SetApiStatus(false);
             }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async Task LoadFavoritesFromApiAsync()
+        {
+            try
+            {
+                var response = await _httpClientService!.GetAsync<RecipeListResponse>("/collections/favorites");
+
+                var list = new List<Recipe>();
+
+                if (response?.Recipes?.Any() == true)
+                {
+                    foreach (var recipe in response.Recipes)
+                    {
+                        recipe.SyncFromApi();
+                        list.Add(recipe);
+                    }
+                }
+
+                list = SortFavorites(list);
+
+                FavoriteRecipes = new ObservableCollection<Recipe>(list);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[FavoritesViewModel] API error: {ex.Message}");
+                LoadFavoritesFromMock();
+                SetApiStatus(false);
+            }
+        }
+
+        private void LoadFavoritesFromMock()
+        {
+            var allRecipes = _mockDataService.GetRecipesInstance();
+            var favorites = allRecipes.Where(r => r.IsFavorited).ToList();
+
+            favorites = SortFavorites(favorites);
+
+            FavoriteRecipes = new ObservableCollection<Recipe>(favorites);
+        }
+
+        private List<Recipe> SortFavorites(List<Recipe> favorites)
+        {
+            return SortOption switch
+            {
+                "Latest" => favorites.OrderByDescending(r => r.CreatedDate).ToList(),
+                "Rating" => favorites.OrderByDescending(r => r.Rating).ToList(),
+                "Cooking Time" => favorites.OrderBy(r => r.TotalTimeMinutes).ToList(),
+                "Alphabetical" => favorites.OrderBy(r => r.Title).ToList(),
+                _ => favorites.OrderByDescending(r => r.CreatedDate).ToList()
+            };
         }
 
         partial void OnSortOptionChanged(string value)
         {
-            LoadFavorites();
+            _ = LoadFavoritesAsync();
         }
 
         [RelayCommand]
@@ -98,13 +175,11 @@ namespace ReciptShare.ViewModels
         private async Task RefreshFavorites()
         {
             IsRefreshing = true;
-            
+
             try
             {
-                // Simulate network delay
-                await Task.Delay(1000);
-                
-                LoadFavorites();
+                await Task.Delay(500);
+                await LoadFavoritesAsync();
             }
             finally
             {
@@ -124,6 +199,7 @@ namespace ReciptShare.ViewModels
             if (!string.IsNullOrEmpty(action) && action != "Cancel")
             {
                 SortOption = action;
+                await LoadFavoritesAsync();
             }
         }
 

--- a/ReciptShare/ViewModels/LoginViewModel.cs
+++ b/ReciptShare/ViewModels/LoginViewModel.cs
@@ -1,0 +1,90 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ReciptShare.Services;
+using ReciptShare.Models.Api;
+using Microsoft.Maui.Controls;
+
+namespace ReciptShare.ViewModels
+{
+    public partial class LoginViewModel : BaseViewModel
+    {
+        [ObservableProperty]
+        private string emailOrUsername = string.Empty;
+
+        [ObservableProperty]
+        private string password = string.Empty;
+
+        [ObservableProperty]
+        private string statusMessage = string.Empty;
+
+        private readonly IAuthenticationService _authService;
+        private readonly IHttpClientService _httpClientService;
+
+        public LoginViewModel(IAuthenticationService authService, IHttpClientService httpClientService)
+        {
+            Title = "Login";
+            _authService = authService;
+            _httpClientService = httpClientService;
+        }
+
+        // Parameterless constructor for XAML preview/fallback
+        public LoginViewModel() : this(new AuthenticationService(new HttpClientService()), new HttpClientService())
+        {
+        }
+
+        [RelayCommand]
+        private async Task NavigateToRegister()
+        {
+            await Shell.Current.GoToAsync("//register");
+        }
+
+        [RelayCommand]
+        private async Task NavigateToHome()
+        {
+            await Shell.Current.GoToAsync("//home");
+        }
+
+        [RelayCommand]
+        private async Task LoginAsync()
+        {
+            if (IsBusy)
+                return;
+
+            IsBusy = true;
+
+            try
+            {
+                await _httpClientService.CheckApiHealthAsync();
+                SetApiStatus(_httpClientService.IsApiAvailable);
+
+                if (!_httpClientService.IsApiAvailable)
+                {
+                    StatusMessage = "API unavailable. Login requires connection.";
+                    return;
+                }
+
+                var user = await _authService.LoginAsync(EmailOrUsername, Password);
+                if (user != null)
+                {
+                    await Shell.Current.GoToAsync("//home");
+                }
+                else
+                {
+                    StatusMessage = "Invalid credentials.";
+                }
+            }
+            catch (ApiException ex)
+            {
+                StatusMessage = ex.Message;
+            }
+            catch (Exception ex)
+            {
+                StatusMessage = $"Error: {ex.Message}";
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+    }
+}

--- a/ReciptShare/ViewModels/RecipeDetailViewModel.cs
+++ b/ReciptShare/ViewModels/RecipeDetailViewModel.cs
@@ -1,13 +1,16 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ReciptShare.Models;
+using ReciptShare.Models.Api;
 using ReciptShare.Services;
 using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace ReciptShare.ViewModels
 {
     [QueryProperty(nameof(RecipeId), "id")]
-    public partial class ReciptDetailViewModel : BaseViewModel
+    public partial class RecipeDetailViewModel : BaseViewModel
     {
         [ObservableProperty]
         Recipe currentRecipe;
@@ -39,56 +42,132 @@ namespace ReciptShare.ViewModels
         [ObservableProperty]
         int recipeId;
 
-        public ReciptDetailViewModel()
+        private readonly MockDataService _mockDataService;
+        private readonly IHttpClientService? _httpClientService;
+
+        public RecipeDetailViewModel(MockDataService mockDataService, IHttpClientService httpClientService)
         {
             Title = "Recipe Details";
-            CurrentUser = MockDataService.GetCurrentUser();
+            _mockDataService = mockDataService;
+            _httpClientService = httpClientService;
+
+            CurrentUser = _mockDataService.GetCurrentUserInstance();
             Comments = new ObservableCollection<Comment>();
             Ratings = new ObservableCollection<Rating>();
             InstructionsWithNumbers = new ObservableCollection<NumberedInstruction>();
         }
 
-        partial void OnRecipeIdChanged(int value)
+        public RecipeDetailViewModel() : this(new MockDataService(), new HttpClientService())
         {
-            LoadRecipeData(value);
         }
 
-        private void LoadRecipeData(int id)
+        partial void OnRecipeIdChanged(int value)
+        {
+            _ = LoadRecipeDataAsync(value);
+        }
+
+        private async Task LoadRecipeDataAsync(int id)
         {
             try
             {
-                CurrentRecipe = MockDataService.GetRecipeById(id);
+                if (_httpClientService != null)
+                {
+                    await _httpClientService.CheckApiHealthAsync();
+                }
+
+                if (_httpClientService?.IsApiAvailable == true)
+                {
+                    var response = await _httpClientService.GetAsync<ApiResponse<Recipe>>($"/recipes/{id}");
+                    CurrentRecipe = response?.Data;
+                    CurrentRecipe?.SyncFromApi();
+                }
+                else
+                {
+                    CurrentRecipe = _mockDataService.GetRecipeByIdInstance(id);
+                }
+
                 if (CurrentRecipe != null)
                 {
                     Title = CurrentRecipe.Title;
-                    LoadComments();
-                    LoadRatings();
+                    await LoadComments();
+                    await LoadRatings();
                     LoadNumberedInstructions();
                 }
             }
             catch (Exception ex)
             {
-                // Log error or handle gracefully
-                Shell.Current.DisplayAlert("Error", $"Failed to load recipe: {ex.Message}", "OK");
+                await Shell.Current.DisplayAlert("Error", $"Failed to load recipe: {ex.Message}", "OK");
             }
         }
 
-        private void LoadComments()
+        private async Task LoadComments()
         {
-            var allComments = MockDataService.GetComments();
-            var recipeComments = allComments.Where(c => c.RecipeId == CurrentRecipe.Id).ToList();
             Comments.Clear();
+            if (_httpClientService?.IsApiAvailable == true && !string.IsNullOrEmpty(CurrentRecipe?.ApiId))
+            {
+                try
+                {
+                    var response = await _httpClientService.GetAsync<ApiResponse<List<Comment>>>($"/recipes/{CurrentRecipe!.ApiId}/comments");
+                    if (response?.Data != null)
+                    {
+                        foreach (var c in response.Data)
+                        {
+                            Comments.Add(c);
+                        }
+                    }
+                }
+                catch
+                {
+                    LoadCommentsFromMock();
+                }
+            }
+            else
+            {
+                LoadCommentsFromMock();
+            }
+        }
+
+        private void LoadCommentsFromMock()
+        {
+            var allComments = _mockDataService.GetCommentsInstance();
+            var recipeComments = allComments.Where(c => c.RecipeId == CurrentRecipe!.Id).ToList();
             foreach (var comment in recipeComments)
             {
                 Comments.Add(comment);
             }
         }
 
-        private void LoadRatings()
+        private async Task LoadRatings()
         {
-            var allRatings = MockDataService.GetRatings();
-            var recipeRatings = allRatings.Where(r => r.RecipeId == CurrentRecipe.Id).ToList();
             Ratings.Clear();
+            if (_httpClientService?.IsApiAvailable == true && !string.IsNullOrEmpty(CurrentRecipe?.ApiId))
+            {
+                try
+                {
+                    var response = await _httpClientService.GetAsync<ApiResponse<List<Rating>>>($"/recipes/{CurrentRecipe!.ApiId}/ratings");
+                    if (response?.Data != null)
+                    {
+                        foreach (var r in response.Data)
+                        {
+                            Ratings.Add(r);
+                        }
+                    }
+                }
+                catch
+                {
+                    LoadRatingsFromMock();
+                }
+            }
+            else
+            {
+                LoadRatingsFromMock();
+            }
+        }
+
+        private void LoadRatingsFromMock()
+        {
+            var allRatings = _mockDataService.GetRatingsInstance();
+            var recipeRatings = allRatings.Where(r => r.RecipeId == CurrentRecipe!.Id).ToList();
             foreach (var rating in recipeRatings)
             {
                 Ratings.Add(rating);

--- a/ReciptShare/ViewModels/RegisterViewModel.cs
+++ b/ReciptShare/ViewModels/RegisterViewModel.cs
@@ -1,0 +1,111 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ReciptShare.Services;
+using ReciptShare.Models.Api;
+using Microsoft.Maui.Controls;
+
+namespace ReciptShare.ViewModels
+{
+    public partial class RegisterViewModel : BaseViewModel
+    {
+        [ObservableProperty]
+        private string username = string.Empty;
+
+        [ObservableProperty]
+        private string email = string.Empty;
+
+        [ObservableProperty]
+        private string password = string.Empty;
+
+        [ObservableProperty]
+        private string firstName = string.Empty;
+
+        [ObservableProperty]
+        private string lastName = string.Empty;
+
+        [ObservableProperty]
+        private string bio = string.Empty;
+
+        [ObservableProperty]
+        private string statusMessage = string.Empty;
+
+        private readonly IAuthenticationService _authService;
+        private readonly IHttpClientService _httpClientService;
+
+        public RegisterViewModel(IAuthenticationService authService, IHttpClientService httpClientService)
+        {
+            Title = "Register";
+            _authService = authService;
+            _httpClientService = httpClientService;
+        }
+
+        public RegisterViewModel() : this(new AuthenticationService(new HttpClientService()), new HttpClientService())
+        {
+        }
+
+        [RelayCommand]
+        private async Task NavigateToLogin()
+        {
+            await Shell.Current.GoToAsync("//login");
+        }
+
+        [RelayCommand]
+        private async Task NavigateToHome()
+        {
+            await Shell.Current.GoToAsync("//home");
+        }
+
+        [RelayCommand]
+        private async Task RegisterAsync()
+        {
+            if (IsBusy)
+                return;
+
+            IsBusy = true;
+
+            try
+            {
+                await _httpClientService.CheckApiHealthAsync();
+                SetApiStatus(_httpClientService.IsApiAvailable);
+
+                if (!_httpClientService.IsApiAvailable)
+                {
+                    StatusMessage = "API unavailable. Registration requires connection.";
+                    return;
+                }
+
+                var request = new RegisterRequest
+                {
+                    Username = Username,
+                    Email = Email,
+                    Password = Password,
+                    FirstName = FirstName,
+                    LastName = string.IsNullOrWhiteSpace(LastName) ? null : LastName,
+                    Bio = string.IsNullOrWhiteSpace(Bio) ? null : Bio
+                };
+
+                var user = await _authService.RegisterAsync(request);
+                if (user != null)
+                {
+                    await Shell.Current.GoToAsync("//home");
+                }
+                else
+                {
+                    StatusMessage = "Registration failed.";
+                }
+            }
+            catch (ApiException ex)
+            {
+                StatusMessage = ex.Message;
+            }
+            catch (Exception ex)
+            {
+                StatusMessage = $"Error: {ex.Message}";
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+    }
+}

--- a/ReciptShare/ViewModels/WelcomeViewModel.cs
+++ b/ReciptShare/ViewModels/WelcomeViewModel.cs
@@ -1,0 +1,26 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.Controls;
+
+namespace ReciptShare.ViewModels;
+
+public partial class WelcomeViewModel : BaseViewModel
+{
+    [RelayCommand]
+    private async Task GoToLogin()
+    {
+        await Shell.Current.GoToAsync("//login");
+    }
+
+    [RelayCommand]
+    private async Task GoToRegister()
+    {
+        await Shell.Current.GoToAsync("//register");
+    }
+
+    [RelayCommand]
+    private async Task ContinueAsGuest()
+    {
+        await Shell.Current.GoToAsync("//home");
+    }
+}

--- a/ReciptShare/Views/AddRecipePage.xaml.cs
+++ b/ReciptShare/Views/AddRecipePage.xaml.cs
@@ -6,10 +6,10 @@ public partial class AddRecipePage : ContentPage
 {
     private AddReciptViewModel _viewModel;
 
-    public AddRecipePage()
+    public AddRecipePage(AddReciptViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new AddReciptViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 

--- a/ReciptShare/Views/BrowsePage.xaml.cs
+++ b/ReciptShare/Views/BrowsePage.xaml.cs
@@ -6,10 +6,10 @@ public partial class BrowsePage : ContentPage
 {
     private BrowseViewModel _viewModel;
 
-    public BrowsePage()
+    public BrowsePage(BrowseViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new BrowseViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 

--- a/ReciptShare/Views/EditProfilePage.xaml.cs
+++ b/ReciptShare/Views/EditProfilePage.xaml.cs
@@ -6,10 +6,10 @@ public partial class EditProfilePage : ContentPage
 {
     private EditProfileViewModel _viewModel;
 
-    public EditProfilePage()
+    public EditProfilePage(EditProfileViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new EditProfileViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 

--- a/ReciptShare/Views/FavoritesPage.xaml.cs
+++ b/ReciptShare/Views/FavoritesPage.xaml.cs
@@ -6,10 +6,10 @@ public partial class FavoritesPage : ContentPage
 {
     private FavoritesViewModel _viewModel;
 
-    public FavoritesPage()
+    public FavoritesPage(FavoritesViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new FavoritesViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 
@@ -17,6 +17,6 @@ public partial class FavoritesPage : ContentPage
     {
         base.OnAppearing();
         // Refresh favorites when page appears (in case favorites were changed on other pages)
-        _viewModel.LoadFavorites();
+        _ = _viewModel.LoadFavoritesAsync();
     }
 }

--- a/ReciptShare/Views/LoginPage.xaml
+++ b/ReciptShare/Views/LoginPage.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="ReciptShare.Views.LoginPage"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:ReciptShare.ViewModels"
+             x:DataType="viewmodels:LoginViewModel"
+             Title="{Binding Title}">
+    <ScrollView>
+    <StackLayout Padding="30" Spacing="20" VerticalOptions="Center">
+        <Image Source="logo.png" HeightRequest="100" HorizontalOptions="Center" />
+        <Label Text="Welcome back!" FontAttributes="Bold" FontSize="Large" HorizontalOptions="Center" />
+        <Entry Text="{Binding EmailOrUsername}" Placeholder="Email or username" />
+        <Entry Text="{Binding Password}" IsPassword="True" Placeholder="Password" />
+        <Button Text="Login" Command="{Binding LoginCommand}" />
+        <Button Text="Register" Command="{Binding NavigateToRegisterCommand}" />
+        <Button Text="Continue as Guest" Command="{Binding NavigateToHomeCommand}" />
+        <Label Text="{Binding StatusMessage}" TextColor="Red" HorizontalOptions="Center" />
+    </StackLayout>
+    </ScrollView>
+</ContentPage>

--- a/ReciptShare/Views/LoginPage.xaml.cs
+++ b/ReciptShare/Views/LoginPage.xaml.cs
@@ -1,0 +1,12 @@
+using ReciptShare.ViewModels;
+
+namespace ReciptShare.Views;
+
+public partial class LoginPage : ContentPage
+{
+    public LoginPage(LoginViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/ReciptShare/Views/ProfilePage.xaml.cs
+++ b/ReciptShare/Views/ProfilePage.xaml.cs
@@ -6,10 +6,10 @@ public partial class ProfilePage : ContentPage
 {
     private ProfileViewModel _viewModel;
 
-    public ProfilePage()
+    public ProfilePage(ProfileViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new ProfileViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 

--- a/ReciptShare/Views/RecipeDetailPage.xaml
+++ b/ReciptShare/Views/RecipeDetailPage.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewmodels="clr-namespace:ReciptShare.ViewModels"
              xmlns:models="clr-namespace:ReciptShare.Models"
-             x:DataType="viewmodels:ReciptDetailViewModel"
+             x:DataType="viewmodels:RecipeDetailViewModel"
              Title="{Binding Title}">
 
     <ScrollView>

--- a/ReciptShare/Views/RecipeDetailPage.xaml.cs
+++ b/ReciptShare/Views/RecipeDetailPage.xaml.cs
@@ -4,14 +4,14 @@ namespace ReciptShare.Views;
 
 public partial class RecipeDetailPage : ContentPage
 {
-    private ReciptDetailViewModel _viewModel;
+    private RecipeDetailViewModel _viewModel;
 
-    public RecipeDetailPage()
+    public RecipeDetailPage(RecipeDetailViewModel viewModel)
     {
         try
         {
             InitializeComponent();
-            _viewModel = new ReciptDetailViewModel();
+            _viewModel = viewModel;
             BindingContext = _viewModel;
         }
         catch (Exception ex)

--- a/ReciptShare/Views/RegisterPage.xaml
+++ b/ReciptShare/Views/RegisterPage.xaml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="ReciptShare.Views.RegisterPage"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:ReciptShare.ViewModels"
+             x:DataType="viewmodels:RegisterViewModel"
+             Title="{Binding Title}">
+    <ScrollView>
+    <StackLayout Padding="30" Spacing="20" VerticalOptions="Center">
+        <Image Source="logo.png" HeightRequest="100" HorizontalOptions="Center" />
+        <Label Text="Username" />
+        <Entry Text="{Binding Username}" Placeholder="Choose a username" />
+        <Label Text="Email" />
+        <Entry Text="{Binding Email}" Placeholder="Enter email" />
+        <Label Text="Password" />
+        <Entry Text="{Binding Password}" IsPassword="True" Placeholder="Create password" />
+        <Label Text="First Name" />
+        <Entry Text="{Binding FirstName}" />
+        <Label Text="Last Name" />
+        <Entry Text="{Binding LastName}" />
+        <Label Text="Bio" />
+        <Editor Text="{Binding Bio}" HeightRequest="60" />
+        <Button Text="Register" Command="{Binding RegisterCommand}" />
+        <Button Text="Back to Login" Command="{Binding NavigateToLoginCommand}" />
+        <Button Text="Continue as Guest" Command="{Binding NavigateToHomeCommand}" />
+        <Label Text="{Binding StatusMessage}" TextColor="Red" />
+    </StackLayout>
+    </ScrollView>
+</ContentPage>

--- a/ReciptShare/Views/RegisterPage.xaml.cs
+++ b/ReciptShare/Views/RegisterPage.xaml.cs
@@ -1,0 +1,12 @@
+using ReciptShare.ViewModels;
+
+namespace ReciptShare.Views;
+
+public partial class RegisterPage : ContentPage
+{
+    public RegisterPage(RegisterViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/ReciptShare/Views/ShoppingListPage.xaml.cs
+++ b/ReciptShare/Views/ShoppingListPage.xaml.cs
@@ -6,10 +6,10 @@ public partial class ShoppingListPage : ContentPage
 {
     private ShoppingListViewModel _viewModel;
 
-    public ShoppingListPage()
+    public ShoppingListPage(ShoppingListViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = new ShoppingListViewModel();
+        _viewModel = viewModel;
         BindingContext = _viewModel;
     }
 

--- a/ReciptShare/Views/WelcomePage.xaml
+++ b/ReciptShare/Views/WelcomePage.xaml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="ReciptShare.Views.WelcomePage"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:ReciptShare.ViewModels"
+             x:DataType="viewmodels:WelcomeViewModel"
+             Title="Welcome">
+    <ScrollView>
+    <StackLayout Padding="30" Spacing="25" VerticalOptions="Center">
+        <Image Source="logo.png" HeightRequest="120" HorizontalOptions="Center" />
+        <Label Text="Welcome to RecipeShare" FontAttributes="Bold" FontSize="Large" HorizontalOptions="Center" />
+        <Label Text="Share and explore amazing recipes" HorizontalOptions="Center" />
+        <Button Text="Login" Command="{Binding GoToLoginCommand}" />
+        <Button Text="Register" Command="{Binding GoToRegisterCommand}" />
+        <Button Text="Continue as Guest" Command="{Binding ContinueAsGuestCommand}" />
+    </StackLayout>
+    </ScrollView>
+</ContentPage>

--- a/ReciptShare/Views/WelcomePage.xaml.cs
+++ b/ReciptShare/Views/WelcomePage.xaml.cs
@@ -1,0 +1,12 @@
+using ReciptShare.ViewModels;
+
+namespace ReciptShare.Views;
+
+public partial class WelcomePage : ContentPage
+{
+    public WelcomePage(WelcomeViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}


### PR DESCRIPTION
## Summary
- wire up `HttpClientService` to `BrowseViewModel` with fallback to mock data
- fetch favorite recipes from the API when available
- update `RecipeDetailViewModel` to load recipe, comments and ratings from the API
- switch XAML page constructors to receive view models via DI
- ignore null values when serializing JSON
- remove unused profile image field from registration
- install .NET 8.0 SDK and attempt to build the solution

## Testing
- `dotnet --version` ➡️ `8.0.116`
- `dotnet build ReciptShare.sln --no-restore` *(fails: workloads `wasi-experimental` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841c2fd21bc8323af8153f5163bfa70